### PR TITLE
build(smithery): add module entry and explicit entry file for Smithery CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@quinn/memory-mcp-server",
   "version": "0.0.1",
   "main": "dist/server.js",
+  "module": "./src/server.ts",
   "type": "module",
   "engines": {
     "node": ">=20"
@@ -10,7 +11,7 @@
     "memory-mcp": "dist/server.js"
   },
   "scripts": {
-    "build": "npx @smithery/cli build",
+    "build": "npx @smithery/cli build src/server.ts",
     "clean": "rm -rf dist",
     "dev": "npx @smithery/cli dev",
     "start": "node dist/server.js"


### PR DESCRIPTION
Smithery CLI requires a module entrypoint in package.json. This PR:\n- Adds \"module\": \"./src/server.ts\"\n- Updates build script to: `npx @smithery/cli build src/server.ts`\n\nResolves Docker build error: entrypoint missing.